### PR TITLE
Use double brackets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+SHELL := /bin/bash
+.SHELLFLAGS := -euo pipefail
+
 SUBMODULES = $(shell git submodule | awk '{ print $$2 }')
 UNAME := $(shell uname)
 

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ endif
 	@for plugin in $(RBENV_PLUGINS); do \
 	(\
 		cd $(ANYENV_DIR)/envs/rbenv/plugins; \
-		if [ ! -d "$$(basename $$plugin)" ]; then \
+		if [[ ! -d "$$(basename $$plugin)" ]]; then \
 			$(GIT_CLONE) https://github.com/$$plugin.git; \
 		fi; \
 	)\
@@ -103,7 +103,7 @@ endif
 homebrew-bundle:
 ifeq ($(UNAME),Darwin)
 	@while read -r line; do \
-		if [ ! -z "$$line" ]; then\
+		if [[ ! -z "$$line" ]]; then\
 			brew $$line || true; \
 		fi; \
 	done < $(PWD)/brewfiles/Brewfile
@@ -128,13 +128,13 @@ submodule-update:
 .PHONY: symlink
 symlink:
 	@for file in $(DOTFILES); do \
-		if [ -n "`grep $$file $(SYMLINKIGNORE)`" ]; then \
+		if [[ -n "`grep $$file $(SYMLINKIGNORE)`" ]]; then \
 			continue; \
 		fi; \
-		if [ $(UNAME) = "Linux" -a $(SYMLINK_MAC_ONLY) = *"$$file"* ]; then \
+		if [[ $(UNAME) = "Linux" && $(SYMLINK_MAC_ONLY) = *"$$file"* ]]; then \
 			continue; \
 		fi; \
-		if [ ! -e $(HOME)/$$file ]; then \
+		if [[ ! -e $(HOME)/$$file ]]; then \
 			ln -sf $(PWD)/$$file $(HOME)/$$file; \
 		fi; \
 	done
@@ -145,7 +145,7 @@ clean: clean-symlink clean-vimplugins
 .PHONY: clean-symlink
 clean-symlink:
 	@for file in $(DOTFILES); do \
-		if [ -e $(HOME)/$$file ]; then \
+		if [[ -e $(HOME)/$$file ]]; then \
 			rm -r $(HOME)/$$file; \
 		fi; \
 	done


### PR DESCRIPTION
To avoid them:

```sh-session
$ make symlink
/bin/sh: line 0: [: too many arguments
```

```sh-session
$ make symlink
/bin/sh: -c: line 0: syntax error in conditional expression
/bin/sh: -c: line 0: syntax error near `-a'
/bin/sh: -c: line 0: `for file in .agignore .aspell.conf .bundle .coffeelint-config.json .ctags .gemrc .gitconfig .gitignore .gitmodules .mailcap .muttrc.sample .peco .railsrc .symlinkignore .tigrc .tmux-Darwin.conf .tmux.conf .tmux .travis.yml .vimrc .xinitrc Makefile README.md brewfiles default-gems dein.toml dein script; do    if [[ -n "`grep $file .symlinkignore`" ]]; then                 continue;       fi;       if [[ Darwin = "Linux" -a .tmux-Darwin.conf = *"$file"* ]]; then                continue;       fi;     if [[ ! -e /Users/dtan4/$file ]]; then            ln -sf /Users/dtan4/src/github.com/dtan4/dotfiles/$file /Users/dtan4/$file;     fi; done'
make: *** [symlink] Error 2
```